### PR TITLE
Update add-manage-eventstream-sources.md

### DIFF
--- a/docs/real-time-analytics/event-streams/add-manage-eventstream-sources.md
+++ b/docs/real-time-analytics/event-streams/add-manage-eventstream-sources.md
@@ -40,7 +40,7 @@ If you have an Azure event hub created with event data there, follow these steps
    - **Connection name**: Enter a name for the cloud connection.
    - **Connection type**: The default value is `EventHub`.
    - **Event Hub namespace**: Enter the name of your Azure event hub namespace.
-   - **Authentication**: Go to your Azure event hub and create a policy with `Manage` or `Listen` permission under **Share access policies**. Then use **policy name** and **primary key** as the **Shared Access Key Name** and **Shared Access Key**.
+   - **Authentication**: Go to your Azure event hub and create a policy with `Manage` permission under **Share access policies**. Then use **policy name** and **primary key** as the **Shared Access Key Name** and **Shared Access Key**.
 
        :::image type="content" source="./media/add-manage-eventstream-sources/azure-event-hub-policy-key.png" alt-text="Screenshot showing the Azure event hub policy key." lightbox="./media/add-manage-eventstream-sources/azure-event-hub-policy-key.png":::
 


### PR DESCRIPTION
Eventstreams in Fabric (preview) does not work with Event Hubs Cloud Connections with only Listen permission. Enabling Manage permission allows the user to successfully attach to an Event Hub source.

If the intention is to eventually support connections with only Listen permission granted, then an alternate documentation change could be adding a note: "Fabric (Preview) currently requires Manage permission".